### PR TITLE
Fix popup offset coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,21 @@ In your CSPROJ file, update the Microsoft.WindowsDesktop.App reference:
 * All commits pushed to the `stable` branch will build a CI package that will be pushed to the Azure Artifacts feed.
 * [Contributing guide](Documentation/contributing.md)
 
+* **First time setup**: If you have problems building for the first time, you may have an incorrect local VS 2022 configuration. To correct this:
+  1. Run the `Visual Studio Installer`
+  2. In `More` menu for VS 2022, choose `Import configuration` select the file `Documentation\wpf.vsconfig`
+  3. Follow the prompts to install everything needed
+
+* **Missing .net SDK**: It is possible to not have the proper SDK for building. If the configuration update above doesn't resolve your build issue install the latest 6.0.xxx (currently `6.0.304`) from [Microsoft's site](https://dotnet.microsoft.com/en-us/download/dotnet/6.0).
+
+## Using a locally built package
+
+* You can't just use the built package directly. This is only a first step compile that needs to be "repackaged" into a usable state.
+  1. Ensure you're running [Powershell 7.3.1](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows?view=powershell-7.3) or later.
+  2. In your root wpf folder run .\eng\Repackage.ps1
+  3. Move the file located in `.\artifacts\packages\Release\Shipping\` To the location you store local testing nuget packages.
+  4. Update the version in your project to match the built version `6.0.14-dev.23063.1`
+
 ## Issues
 
 Open an issue on this repo for problems _specifically with_ this package. All other issues should be opened on [dotnet/wpf](https://github.com/dotnet/wpf/issues).


### PR DESCRIPTION
Fixes Issue #TBD

## Description

Popups that use custom placement options were passing the target/popup using scaled/device sizes, but were passing the offset parameter using the original non-scaled values. This meant the custom code couldn't properly place the popup.

The change is to scale the offset we pass to the placement code using the same scaling method we use for the target/popup.

## Customer Impact

Popups cannot be moved the the right location using Custom Placement if there is an offset and scaling applied.

## Regression

no

## Testing

Manual testing of the code that revealed this issue.

## Risk

If there were users of this code that were somehow making use of the unscaled offset for custom popup placement, they will now be getting a value they don't expect.
